### PR TITLE
Refactoring of inter entity messaging

### DIFF
--- a/base/button.h
+++ b/base/button.h
@@ -11,6 +11,9 @@
 // Publish:
 // - "NAME/push"
 // - "NAME/release"
+//
+// Subscribe:
+// - "NAME/getstate"
 
 #pragma once
 
@@ -28,6 +31,13 @@ namespace meisterwerk {
             button( String name ) : meisterwerk::core::entity( name ) {
                 fromState  = false;
                 lastChange = 0;
+            }
+
+            virtual void onSetup() override {
+                subscribe( entName + "/getstate" );
+            }
+
+            virtual void onReceive( String topic, String msg ) override {
             }
 
             virtual void onChange( bool toState, unsigned long duration ) {

--- a/base/pushbutton.h
+++ b/base/pushbutton.h
@@ -40,7 +40,7 @@ namespace meisterwerk {
                 subscribe( entName + "/config" );
             }
 
-            virtual void onReceiveMessage( String topic, const char *pBuf, unsigned int len ) {
+            virtual void onReceive( String topic, String msg ) override {
                 if ( topic == entName + "/config" ) {
                     // XXX: Parse JSON data and set minLongMs,minExtraLongMs
                 }

--- a/core/entity.h
+++ b/core/entity.h
@@ -47,23 +47,42 @@ namespace meisterwerk {
 
             bool registerEntity( unsigned long minMicroSecs = 0, unsigned int priority = 3 ) {
                 msgregister reg( this, minMicroSecs, priority );
-                if ( sendMessage( message::MSG_DIRECT, "register", (char *)&reg, sizeof( reg ) ) ) {
+                if ( message::send( message::MSG_DIRECT, entName, "register", &reg,
+                                    sizeof( reg ) ) ) {
                     return true;
                 }
                 DBG( "entity::registerEntity, sendMessage failed for register " + entName );
                 return false;
             }
 
-            bool publish( String topic, String msg ) {
-                if ( sendMessage( message::MSG_PUBLISH, topic, msg ) ) {
+            bool publish( String topic ) {
+                if ( message::send( message::MSG_PUBLISH, entName, topic, "{}" ) ) {
                     return true;
                 }
                 DBG( "entity::publish, sendMessage failed for publish " + entName );
                 return false;
             }
 
+            bool publish( String topic, String msg ) {
+                if ( message::send( message::MSG_PUBLISH, entName, topic, msg ) ) {
+                    return true;
+                }
+                DBG( "entity::publish, sendMessage failed for publish " + entName );
+                return false;
+            }
+
+            /* Prepared but not supported in the current scheduler
+            bool publish( String topic, const void *pBuf, unsigned long len ) {
+                if ( message::send( message::MSG_PUBLISHRAW, entName, topic, pBuf, len ) ) {
+                    return true;
+                }
+                DBG( "entity::publish, sendMessage failed for publish " + entName );
+                return false;
+            }
+            */
+
             bool subscribe( String topic ) {
-                if ( sendMessage( message::MSG_SUBSCRIBE, topic, nullptr, 0 ) ) {
+                if ( message::send( message::MSG_SUBSCRIBE, entName, topic, nullptr, 0 ) ) {
                     return true;
                 }
                 DBG( "entity::publish, sendMessage failed for subscribe " + entName );
@@ -78,23 +97,15 @@ namespace meisterwerk {
                 DBG( "entity:onLook, missing override for entity " + entName );
             }
 
-            virtual void onReceiveMessage( String topic, const char *pBuf, unsigned int len ) {
-                DBG( "entity:receiveMessage, missing override for entity " + entName );
+            virtual void onReceive( String topic, String msg ) {
+                DBG( "entity:onReceive(string), missing override for entity " + entName );
             }
 
-            protected:
-            // This sends messages to scheduler via messageQueue
-            bool sendMessage( unsigned int type, String topic, char *pBuf, unsigned int len,
-                              bool isBufAllocated = false ) {
-                // DBG( "entity::sendMessage, from: " + entName + ", topic: " + topic );
-                return message::send( type, entName, topic, pBuf, len, isBufAllocated );
+            /* Prepared but not supported in the current scheduler
+            virtual void onReceive( String topic, const void *pBuf, unsigned int len ) {
+                DBG( "entity:onReceive(binary), missing override for entity " + entName );
             }
-
-            // Send text message to Scheduler
-            bool sendMessage( unsigned int type, String topic, String content ) {
-                // DBG( "entity::sendMessage, from: " + entName + ", topic: " + topic );
-                return message::send( type, entName, topic, content );
-            }
+            */
         };
     } // namespace core
 } // namespace meisterwerk

--- a/core/message.h
+++ b/core/message.h
@@ -30,10 +30,11 @@ namespace meisterwerk {
         class message {
             public:
             // constants
-            static const unsigned int MSG_NONE      = 0;
-            static const unsigned int MSG_DIRECT    = 1;
-            static const unsigned int MSG_PUBLISH   = 2;
-            static const unsigned int MSG_SUBSCRIBE = 3;
+            static const unsigned int MSG_NONE       = 0;
+            static const unsigned int MSG_DIRECT     = 1;
+            static const unsigned int MSG_SUBSCRIBE  = 2;
+            static const unsigned int MSG_PUBLISH    = 3;
+            static const unsigned int MSG_PUBLISHRAW = 3;
 
             // static members
             static queue<message> que;
@@ -43,11 +44,11 @@ namespace meisterwerk {
             unsigned int pBufLen;    // Length of binary buffer pBuf
             char *       originator; // allocated instance name of originator
             char *       topic;      // allocated zero terminated string
-            char *       pBuf;       // allocated bin buffer of size pBufLen
+            void *       pBuf;       // allocated bin buffer of size pBufLen
 
             // static methods
-            static bool send( unsigned int _type, String _originator, String _topic, char *_pBuf,
-                              unsigned int _len, bool isBufAllocated = false ) {
+            static bool send( unsigned int _type, String _originator, String _topic,
+                              const void *_pBuf, unsigned int _len, bool isBufAllocated = false ) {
                 message *msg = new message();
                 if ( msg == nullptr ) {
                     DBG( F( "message::sendMessage, failed to allocate message" ) );
@@ -85,7 +86,7 @@ namespace meisterwerk {
             }
 
             void init( unsigned int _type = 0, char *_originator = nullptr, char *_topic = nullptr,
-                       char *_pBuf = nullptr, unsigned int _pBufLen = 0 ) {
+                       void *_pBuf = nullptr, unsigned int _pBufLen = 0 ) {
                 type       = _type;
                 originator = _originator;
                 topic      = _topic;
@@ -93,7 +94,7 @@ namespace meisterwerk {
                 pBufLen    = _pBufLen;
             }
 
-            bool create( unsigned int _type, String _originator, String _topic, char *_pBuf,
+            bool create( unsigned int _type, String _originator, String _topic, const void *_pBuf,
                          unsigned int _len, bool isBufAllocated = false ) {
                 // DBG( "message::create, from: " + _originator + ", topic: " + _topic );
                 int tLen = _topic.length() + 1;
@@ -128,9 +129,9 @@ namespace meisterwerk {
                 // set content
                 if ( _len > 0 ) {
                     if ( isBufAllocated ) {
-                        pBuf = _pBuf;
+                        pBuf = (void *)_pBuf;
                     } else {
-                        pBuf = (char *)malloc( _len );
+                        pBuf = (void *)malloc( _len );
                         if ( pBuf == nullptr ) {
                             DBG( F( "message::create, Cannot allocate content" ) );
                             discard();

--- a/core/scheduler.h
+++ b/core/scheduler.h
@@ -168,10 +168,10 @@ namespace meisterwerk {
                             if ( pTask->pEnt->entName == sub.subscriber ) {
 #ifdef DEBUG
                                 pTask->msgTime.snap();
-                                pTask->pEnt->onReceiveMessage( topic, pMsg->pBuf, pMsg->pBufLen );
+                                pTask->pEnt->onReceive( topic, (char *)pMsg->pBuf );
                                 pTask->msgTime.shot();
 #else
-                                pTask->pEnt->onReceiveMessage( topic, pMsg->pBuf, pMsg->pBufLen );
+                                pTask->pEnt->onReceive( topic, (char *)pMsg->pBuf );
 #endif
                             }
                         }

--- a/util/dumper.h
+++ b/util/dumper.h
@@ -66,7 +66,7 @@ namespace meisterwerk {
                 }
             }
 
-            virtual void onReceiveMessage( String topic, const char *pBuf, unsigned int len ) {
+            virtual void onReceive( String topic, String msg ) override {
                 if ( topic == debugButton + "/short" ) {
                     dumpRuntimeInfo();
                 } else if ( topic == debugButton + "/long" ) {

--- a/util/messagespy.h
+++ b/util/messagespy.h
@@ -42,14 +42,9 @@ namespace meisterwerk {
                 tmpSubscribedTopic = "";
             }
 
-            virtual void onReceiveMessage( String topic, const char *pBuf,
-                                           unsigned int len ) override {
-                if ( len = 0 ) {
-                    Serial.println( "messagespy(" + entName + "): topic='" + topic + "'" );
-                } else {
-                    Serial.println( "messagespy(" + entName + "): topic='" + topic + "' body='" +
-                                    String( pBuf ) + "'" );
-                }
+            virtual void onReceive( String topic, String msg ) override {
+                Serial.println( "messagespy(" + entName + "): topic='" + topic + "' body='" + msg +
+                                "'" );
             }
 #endif
         };


### PR DESCRIPTION
Messages between entities have now a text only payload. The reception callback was renamed to `onReceive`