### PR TITLE
Feature/i2cbus

### DIFF
--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -241,8 +241,7 @@ namespace meisterwerk {
                     i2cScan();
                 }
             }
-            virtual void onReceiveMessage( String topic, const char *pBuf,
-                                           unsigned int len ) override {
+            virtual void onReceive( String topic, String msg ) override {
                 if ( topic == "i2cbus/enum" ) {
                     DBG("i2cbus: received enum request.");
                     i2cScan();

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -1,0 +1,220 @@
+
+#ifndef i2cbus_h
+#define i2cbus_h
+
+// dependencies
+#include "../core/entity.h"
+
+// This is based on: http://www.ladyada.net/library/i2caddr.html
+// and web dom's sensorclock research
+
+// I2C addresses used:
+// Luminosity (TSL2561)    0x39
+// OLED Display            0x3c
+// RTC Eeprom              0x50
+// RTC                     0x68
+// SevenSegment (Adafruit) 0x70
+// Barometer (BMP085):     0x77
+
+enum I2CDevType {
+    OLED,
+    Sensor,
+    RTC,
+    IO,
+    PWM,
+    DAC,
+    Radio,
+    Touch,
+    EEPROM,
+}
+
+enum I2CDev {
+    SSD1306,
+    PN532,
+    TSL2561,
+    BMP085,
+    ADXL345,
+    HMC5883L,
+    BMA180,
+    MMA7455L,
+    VCNL4000,
+    ITG3200,
+    MS5607,
+    MS5611,
+    LSM9DS0_Accel_Mag,
+    LSM9DS0_Gyro,
+    LSM303_Accel,
+    LSM303_Mag,
+    DS1307,
+    DS1307_EEPROM,
+    DS3231,
+    MCP23008,
+    MCP23017,
+    PCA9685,
+    MCP4725A0,
+    MCP4725A1,
+    MCP4725A2,
+    MCP4725A3,
+    TEA5767,
+    Si4713,
+    FT6206,
+    STMPE610
+}
+
+typedef struct t_i2c_properties {
+    I2CDev                     id;
+    I2CDevType                 type;
+    String                     name;
+    String                     description;
+    bool                       supported;
+    std::vector<unsigned char> addresses;
+} T_I2C_PROPERTIES
+
+    const T_I2C_PROPERTIES i2cProps[] PROGMEM = {
+        {OLED, SSD1306, "SSD1306", "OLED-display (128x64)", false, {0x3C, 0x3D}},
+        // http://www.solomon-systech.com/en/product/display-ic/oled-driver-controller/ssd1306/
+        {NFC, PN532, "PN532", "RFID controller", false, {0x48}},
+        // https://www.adafruit.com/product/364
+        {Sensor, TSL2561, "TSL2561", "Luminosity sensor", false, {0x29, 0x39, 0x49}},
+        // https://www.adafruit.com/product/439
+        {Sensor,
+         BMP085,
+         "BMP085",
+         "Barometric pressure, temperature, altitude Sensor",
+         false,
+         {0x77}},
+        // https://www.adafruit.com/product/391
+        {Sensor, ADXL345, "ADXL345", "Accelerometer", false, {0x1D, 0x53}},
+        // http://www.analog.com/en/products/mems/accelerometers/adxl345.html
+        {Sensor, HMC5883L, "HMC5883L", "Magnetic compass", false, {0x1E}},
+        // https://aerospace.honeywell.com/en/products/navigation-and-sensors/magnetic-sensors-and-transducers
+        {Sensor, BMA180, "BMA180", "3 axis accelerometer", false, {0x77}},
+        // http://www.geeetech.com/wiki/index.php/BMA180_Triple_Axis_Accelerometer_Breakout
+        {Sensor, VCNL4000, "VCNL4000", "Proximity light sensor", false, {0x13}},
+        // https://www.adafruit.com/product/466
+        {Sensor, ITG3200, "ITG3200", "3 axis accelerometer", false, {0x68, 0x69}},
+        // https://www.invensense.com/products/motion-tracking/3-axis/itg-3200/
+        {Sensor, MS5607, "MS5607", "Altimeter", false, {0x76, 0x77}},
+        // https://www.parallax.com/product/29124
+        {Sensor, MS5611, "MS5611", "Barometric pressure altitude sensor", false, {0x76, 0x77}},
+        // http://www.amsys.info/products/ms5611.htm
+        {Sensor, LSM9DS0_Accel_Mag, "LSM9DS0_Accel_Mag", "", false, {0x1D}},
+        {Sensor, LSM9DS0_Gyro, "LSM9DS0_Gyro", "", false, {0x6B}},
+        {Sensor, LSM303_Accel, "LSM303_Accel", "", false, {0x19}},
+        {Sensor, LSM303_Mag, "LSM303_Mag", "", false, {0x1E}},
+        {RTC, DS1307, "DS1307", "", false, {0x68}},
+        {RTC, DS3231, "DS3231", "", false, {0x68}},
+        {EEPROM, DS1307_EEPROM, "DS1307_EEPORM", "", false, {0x50}},
+        {IO, MCP23008, "MCP23008", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
+        {IO, MCP23017, "MCP23017", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
+        {PWM,
+         PCA9685,
+         "PCA9685",
+         "",
+         false,
+         {0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E,
+          0x4F}},
+        {DAC, MCP4725A0, "MCP4725A0", "", false, {0x60, 0x61}},
+        {DAC, MCP4725A1, "MCP4725A1", "", false, {0x62, 0x63}},
+        {DAC, MCP4725A2, "MCP4725A2", "", false, {0x64, 0x65}},
+        {DAC, MCP4725A3, "MCP4725A3", "", false, {0x66, 0x67}},
+        {Radio, TEA5767, "TEA5767", "", false, {0x60}},
+        {Radio, Si4713, "Si4713", "", false, {0x11, 0x63}},
+        {Touch, FT6206, "FT6206", "", false, {0x38}},
+        {Touch, STMPE610, "STMPE610", "", false, {0x41}}};
+
+namespace meisterwerk {
+    namespace base {
+        class i2cbus : public meisterwerk::core::entity {
+            public:
+            bool         bSetup;
+            bool         bEnum;
+            bool         bInternalError;
+            uint8_5      sdaport, sclport;
+            unsigned int nDevices;
+
+            i2cbus( String name, int sdaport, int sclport )
+                : meisterwerk::core::entity( name ), sdaport{sdaport}, sclport{sclport} {
+                bSetup         = false;
+                bEnum          = false;
+                bInternalError = false;
+            }
+
+            virtual void onSetup() override {
+                Wire.begin( sdaport, sclport ); // SDA, SCL;
+                bSetup = true;
+                bEnum  = false;
+            }
+
+            bool check( uint8_t address ) {
+                bool bDevFound = false;
+                Wire.beginTransmission( address );
+                error = Wire.endTransmission();
+
+                if ( error == 0 ) {
+                    bDevFound = true;
+                    DBG( "I2C device found at address " + String( address ) + " (dec.)" );
+                } else if ( error == 4 ) {
+                    DBG( "Unknow error at address " + String( address ) + " (dec.)" );
+                }
+                return bDevFound;
+            }
+
+            unsigned int i2cScan() {
+                byte   error, address;
+                String portlist = "";
+
+                if ( !bSetup ) {
+                    DBG( "i2cbus not initialized!" );
+                    publish( "i2cbus/offline", "" );
+                    bInternalError = true;
+                    return 0;
+                }
+
+                DBG( "Scanning I2C-Bus, SDA=" + String( sdaport ) + ", SCL=" + String( sclport ) );
+                subscribe( "i2cbus/*" );
+
+                nDevices = 0;
+                for ( uint8_t address = 1; address < 127; address++ ) {
+                    // The i2c_scanner uses the return value of
+                    // the Write.endTransmisstion to see if
+                    // a device did acknowledge to the address.
+                    // From: https://playground.arduino.cc/Main/I2cScanner
+                    if ( check( address ) ) {
+                        nDevices++;
+                        if ( nDevices > 1 )
+                            portlist += ",";
+                        portlist += String( address );
+                    }
+                }
+                if ( nDevices == 0 ) {
+                    DBG( "No I2C devices found\n" );
+                    publish( "i2cbus/offline", "" );
+                } else {
+                    String json =
+                        "{\"devs\":" + String( nDevices ) + ",\"portlist\": [" + portlist "]}";
+                    DBG( "jsonstate i2c:" + json );
+                    publish( "i2cbus/online", json );
+                }
+                bEnum = true;
+                return nDevices;
+            }
+
+            virtual void onLoop( unsigned long ticker ) override {
+                if ( bInternalError )
+                    return;
+                if ( !bEnum ) {
+                    i2cScan();
+                }
+            }
+            virtual void onReceiveMessage( String topic, const char *pBuf,
+                                           unsigned int len ) override {
+                if (topic=="i2cbus/enum") {
+                    i2cScan();
+                }
+            }
+        };
+    } // namespace base
+} // namespace meisterwerk
+
+#endif

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -152,7 +152,8 @@ namespace meisterwerk {
                 Wire.begin( sdaport, sclport ); // SDA, SCL;
                 bSetup = true;
                 bEnum  = false;
-            }
+                subscribe( "i2cbus/enum" );
+           }
 
             int identify(uint8_t address) {
                 int numDevs=0;
@@ -209,10 +210,7 @@ namespace meisterwerk {
                     bInternalError = true;
                     return 0;
                 }
-
                 DBG( "Scanning I2C-Bus, SDA=" + String( sdaport ) + ", SCL=" + String( sclport ) );
-                subscribe( "i2cbus/enum" );
-
                 nDevices = 0;
                 niDevs = 0;
                 for ( uint8_t address = 1; address < 127; address++ ) {
@@ -253,6 +251,7 @@ namespace meisterwerk {
             virtual void onReceiveMessage( String topic, const char *pBuf,
                                            unsigned int len ) override {
                 if ( topic == "i2cbus/enum" ) {
+                    DBG("i2cbus: received enum request.");
                     i2cScan();
                 }
             }

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -7,6 +7,7 @@
 
 // dependencies
 #include "../core/entity.h"
+#include "../util/hextools.h"
 
 // This is based on: http://www.ladyada.net/library/i2caddr.html
 // and web dom's sensorclock research
@@ -134,14 +135,6 @@ namespace meisterwerk {
                 bSetup         = false;
                 bEnum          = false;
                 bInternalError = false;
-                DBG("INIT i2c");
-            }
-
-            String hexByte(uint8_t byte) {
-                char b[3];
-                itoa(byte,b,16);
-                if (byte<16) return "0"+String(b);
-                else return String(b);
             }
 
             bool registerEntity() {

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -62,61 +62,61 @@ enum I2CDev {
 }
 
 typedef struct t_i2c_properties {
-    I2CDev                     id;
-    I2CDevType                 type;
-    String                     name;
-    String                     description;
-    bool                       supported;
-    std::vector<unsigned char> addresses;
-} T_I2C_PROPERTIES
+    I2CDev        id;
+    I2CDevType    type;
+    String        name;
+    String        description;
+    bool          supported;
+    unsigned char addresses{};
+} T_I2C_PROPERTIES;
 
-    const T_I2C_PROPERTIES i2cProps[] PROGMEM = {
-        {OLED, SSD1306, "SSD1306", "OLED-display (128x64)", false, {0x3C, 0x3D}},
-        // http://www.solomon-systech.com/en/product/display-ic/oled-driver-controller/ssd1306/
-        {NFC, PN532, "PN532", "RFID controller", false, {0x48}},
-        // https://www.adafruit.com/product/364
-        {Sensor, TSL2561, "TSL2561", "Luminosity sensor", false, {0x29, 0x39, 0x49}},
-        // https://www.adafruit.com/product/439
-        {Sensor, BMP085, "BMP085", "Pressure, temperature, altitude Sensor", false, {0x77}},
-        // https://www.adafruit.com/product/391
-        {Sensor, ADXL345, "ADXL345", "Accelerometer", false, {0x1D, 0x53}},
-        // http://www.analog.com/en/products/mems/accelerometers/adxl345.html
-        {Sensor, HMC5883L, "HMC5883L", "Magnetic compass", false, {0x1E}},
-        // https://aerospace.honeywell.com/en/products/navigation-and-sensors/magnetic-sensors-and-transducers
-        {Sensor, BMA180, "BMA180", "3 axis accelerometer", false, {0x77}},
-        // http://www.geeetech.com/wiki/index.php/BMA180_Triple_Axis_Accelerometer_Breakout
-        {Sensor, VCNL4000, "VCNL4000", "Proximity light sensor", false, {0x13}},
-        // https://www.adafruit.com/product/466
-        {Sensor, ITG3200, "ITG3200", "3 axis accelerometer", false, {0x68, 0x69}},
-        // https://www.invensense.com/products/motion-tracking/3-axis/itg-3200/
-        {Sensor, MS5607, "MS5607", "Altimeter", false, {0x76, 0x77}},
-        // https://www.parallax.com/product/29124
-        {Sensor, MS5611, "MS5611", "Barometric pressure altitude sensor", false, {0x76, 0x77}},
-        // http://www.amsys.info/products/ms5611.htm
-        {Sensor, LSM9DS0_Accel_Mag, "LSM9DS0_Accel_Mag", "", false, {0x1D}},
-        {Sensor, LSM9DS0_Gyro, "LSM9DS0_Gyro", "", false, {0x6B}},
-        {Sensor, LSM303_Accel, "LSM303_Accel", "", false, {0x19}},
-        {Sensor, LSM303_Mag, "LSM303_Mag", "", false, {0x1E}},
-        {RTC, DS1307, "DS1307", "", false, {0x68}},
-        {RTC, DS3231, "DS3231", "", false, {0x68}},
-        {EEPROM, DS1307_EEPROM, "DS1307_EEPORM", "", false, {0x50}},
-        {IO, MCP23008, "MCP23008", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
-        {IO, MCP23017, "MCP23017", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
-        {PWM,
-         PCA9685,
-         "PCA9685",
-         "",
-         false,
-         {0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E,
-          0x4F}},
-        {DAC, MCP4725A0, "MCP4725A0", "", false, {0x60, 0x61}},
-        {DAC, MCP4725A1, "MCP4725A1", "", false, {0x62, 0x63}},
-        {DAC, MCP4725A2, "MCP4725A2", "", false, {0x64, 0x65}},
-        {DAC, MCP4725A3, "MCP4725A3", "", false, {0x66, 0x67}},
-        {Radio, TEA5767, "TEA5767", "", false, {0x60}},
-        {Radio, Si4713, "Si4713", "", false, {0x11, 0x63}},
-        {Touch, FT6206, "FT6206", "", false, {0x38}},
-        {Touch, STMPE610, "STMPE610", "", false, {0x41}}};
+const T_I2C_PROPERTIES i2cProps[] PROGMEM = {
+    {OLED, SSD1306, "SSD1306", "OLED-display (128x64)", false, {0x3C, 0x3D}},
+    // http://www.solomon-systech.com/en/product/display-ic/oled-driver-controller/ssd1306/
+    {NFC, PN532, "PN532", "RFID controller", false, {0x48}},
+    // https://www.adafruit.com/product/364
+    {Sensor, TSL2561, "TSL2561", "Luminosity sensor", false, {0x29, 0x39, 0x49}},
+    // https://www.adafruit.com/product/439
+    {Sensor, BMP085, "BMP085", "Pressure, temperature, altitude Sensor", false, {0x77}},
+    // https://www.adafruit.com/product/391
+    {Sensor, ADXL345, "ADXL345", "Accelerometer", false, {0x1D, 0x53}},
+    // http://www.analog.com/en/products/mems/accelerometers/adxl345.html
+    {Sensor, HMC5883L, "HMC5883L", "Magnetic compass", false, {0x1E}},
+    // https://aerospace.honeywell.com/en/products/navigation-and-sensors/magnetic-sensors-and-transducers
+    {Sensor, BMA180, "BMA180", "3 axis accelerometer", false, {0x77}},
+    // http://www.geeetech.com/wiki/index.php/BMA180_Triple_Axis_Accelerometer_Breakout
+    {Sensor, VCNL4000, "VCNL4000", "Proximity light sensor", false, {0x13}},
+    // https://www.adafruit.com/product/466
+    {Sensor, ITG3200, "ITG3200", "3 axis accelerometer", false, {0x68, 0x69}},
+    // https://www.invensense.com/products/motion-tracking/3-axis/itg-3200/
+    {Sensor, MS5607, "MS5607", "Altimeter", false, {0x76, 0x77}},
+    // https://www.parallax.com/product/29124
+    {Sensor, MS5611, "MS5611", "Barometric pressure altitude sensor", false, {0x76, 0x77}},
+    // http://www.amsys.info/products/ms5611.htm
+    {Sensor, LSM9DS0_Accel_Mag, "LSM9DS0_Accel_Mag", "", false, {0x1D}},
+    {Sensor, LSM9DS0_Gyro, "LSM9DS0_Gyro", "", false, {0x6B}},
+    {Sensor, LSM303_Accel, "LSM303_Accel", "", false, {0x19}},
+    {Sensor, LSM303_Mag, "LSM303_Mag", "", false, {0x1E}},
+    {RTC, DS1307, "DS1307", "", false, {0x68}},
+    {RTC, DS3231, "DS3231", "", false, {0x68}},
+    {EEPROM, DS1307_EEPROM, "DS1307_EEPORM", "", false, {0x50}},
+    {IO, MCP23008, "MCP23008", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
+    {IO, MCP23017, "MCP23017", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
+    {PWM,
+     PCA9685,
+     "PCA9685",
+     "",
+     false,
+     {0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E,
+      0x4F}},
+    {DAC, MCP4725A0, "MCP4725A0", "", false, {0x60, 0x61}},
+    {DAC, MCP4725A1, "MCP4725A1", "", false, {0x62, 0x63}},
+    {DAC, MCP4725A2, "MCP4725A2", "", false, {0x64, 0x65}},
+    {DAC, MCP4725A3, "MCP4725A3", "", false, {0x66, 0x67}},
+    {Radio, TEA5767, "TEA5767", "", false, {0x60}},
+    {Radio, Si4713, "Si4713", "", false, {0x11, 0x63}},
+    {Touch, FT6206, "FT6206", "", false, {0x38}},
+    {Touch, STMPE610, "STMPE610", "", false, {0x41}}};
 
 namespace meisterwerk {
     namespace base {
@@ -125,7 +125,7 @@ namespace meisterwerk {
             bool         bSetup;
             bool         bEnum;
             bool         bInternalError;
-            uint8_5      sdaport, sclport;
+            uint8_t      sdaport, sclport;
             unsigned int nDevices;
 
             i2cbus( String name, int sdaport, int sclport )

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -77,12 +77,7 @@ typedef struct t_i2c_properties {
         // https://www.adafruit.com/product/364
         {Sensor, TSL2561, "TSL2561", "Luminosity sensor", false, {0x29, 0x39, 0x49}},
         // https://www.adafruit.com/product/439
-        {Sensor,
-         BMP085,
-         "BMP085",
-         "Barometric pressure, temperature, altitude Sensor",
-         false,
-         {0x77}},
+        {Sensor, BMP085, "BMP085", "Pressure, temperature, altitude Sensor", false, {0x77}},
         // https://www.adafruit.com/product/391
         {Sensor, ADXL345, "ADXL345", "Accelerometer", false, {0x1D, 0x53}},
         // http://www.analog.com/en/products/mems/accelerometers/adxl345.html
@@ -209,7 +204,7 @@ namespace meisterwerk {
             }
             virtual void onReceiveMessage( String topic, const char *pBuf,
                                            unsigned int len ) override {
-                if (topic=="i2cbus/enum") {
+                if ( topic == "i2cbus/enum" ) {
                     i2cScan();
                 }
             }

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -49,7 +49,7 @@ enum I2CDev {
     LSM9DS0_Gyro,
     LSM303_Accel,
     LSM303_Mag,
-    DS1307,
+    DS1307_3231,
     DS1307_EEPROM,
     DS3231,
     MCP23008,
@@ -65,64 +65,60 @@ enum I2CDev {
     STMPE610
 };
 
+#define MAX_I2C_ADDRESS_VAR 4
 typedef struct t_i2c_properties {
     I2CDevType        id;
     I2CDev    type;
     String        name;
     String        description;
     bool          supported;
-    unsigned char addresses[16];
+    unsigned char addresses[MAX_I2C_ADDRESS_VAR];
 } T_I2C_PROPERTIES;
 
-/*
+
 const T_I2C_PROPERTIES i2cProps[] = {
-    {OLED, SSD1306, "SSD1306", "OLED-display (128x64)", false, {0x3C, 0x3D}},
+    {OLED, SSD1306, "SSD1306", "OLED-display (128x64)", false, {0x3C, 0x3D, 0, 0}},
     // http://www.solomon-systech.com/en/product/display-ic/oled-driver-controller/ssd1306/
-    {NFC, PN532, "PN532", "RFID controller", false, {0x48}},
+    // {NFC, PN532, "PN532", "RFID controller", false, {0x48}},
     // https://www.adafruit.com/product/364
-    {Sensor, TSL2561, "TSL2561", "Luminosity sensor", false, {0x29, 0x39, 0x49}},
+    {Sensor, TSL2561, "TSL2561", "Luminosity sensor", false, {0x29, 0x39, 0x49, 0}},
     // https://www.adafruit.com/product/439
-    {Sensor, BMP085, "BMP085", "Pressure, temperature, altitude Sensor", false, {0x77}},
+    {Sensor, BMP085, "BMP085", "Pressure, temperature, altitude sensor", false, {0x77, 0, 0, 0}},
     // https://www.adafruit.com/product/391
-    {Sensor, ADXL345, "ADXL345", "Accelerometer", false, {0x1D, 0x53}},
+    // {Sensor, ADXL345, "ADXL345", "Accelerometer", false, {0x1D, 0x53}},
     // http://www.analog.com/en/products/mems/accelerometers/adxl345.html
-    {Sensor, HMC5883L, "HMC5883L", "Magnetic compass", false, {0x1E}},
+    {Sensor, HMC5883L, "HMC5883L", "Magnetic compass", false, {0x1E, 0, 0, 0}}, // Also GY271
     // https://aerospace.honeywell.com/en/products/navigation-and-sensors/magnetic-sensors-and-transducers
-    {Sensor, BMA180, "BMA180", "3 axis accelerometer", false, {0x77}},
+    // {Sensor, BMA180, "BMA180", "3 axis accelerometer", false, {0x77}},
     // http://www.geeetech.com/wiki/index.php/BMA180_Triple_Axis_Accelerometer_Breakout
-    {Sensor, VCNL4000, "VCNL4000", "Proximity light sensor", false, {0x13}},
+    {Sensor, VCNL4000, "VCNL4000", "Proximity light sensor", false, {0x13, 0, 0, 0}},
     // https://www.adafruit.com/product/466
-    {Sensor, ITG3200, "ITG3200", "3 axis accelerometer", false, {0x68, 0x69}},
+    //{Sensor, ITG3200, "ITG3200", "3 axis accelerometer", false, {0x68, 0x69}},
     // https://www.invensense.com/products/motion-tracking/3-axis/itg-3200/
-    {Sensor, MS5607, "MS5607", "Altimeter", false, {0x76, 0x77}},
+    //{Sensor, MS5607, "MS5607", "Altimeter", false, {0x76, 0x77}},
     // https://www.parallax.com/product/29124
-    {Sensor, MS5611, "MS5611", "Barometric pressure altitude sensor", false, {0x76, 0x77}},
+    //{Sensor, MS5611, "MS5611", "Barometric pressure altitude sensor", false, {0x76, 0x77}},
     // http://www.amsys.info/products/ms5611.htm
-    {Sensor, LSM9DS0_Accel_Mag, "LSM9DS0_Accel_Mag", "", false, {0x1D}},
-    {Sensor, LSM9DS0_Gyro, "LSM9DS0_Gyro", "", false, {0x6B}},
-    {Sensor, LSM303_Accel, "LSM303_Accel", "", false, {0x19}},
-    {Sensor, LSM303_Mag, "LSM303_Mag", "", false, {0x1E}},
-    {RTC, DS1307, "DS1307", "", false, {0x68}},
-    {RTC, DS3231, "DS3231", "", false, {0x68}},
-    {EEPROM, DS1307_EEPROM, "DS1307_EEPORM", "", false, {0x50}},
-    {IO, MCP23008, "MCP23008", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
-    {IO, MCP23017, "MCP23017", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
-    {PWM,
-     PCA9685,
-     "PCA9685",
-     "",
-     false,
-     {0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E,
-      0x4F}},
-    {DAC, MCP4725A0, "MCP4725A0", "", false, {0x60, 0x61}},
-    {DAC, MCP4725A1, "MCP4725A1", "", false, {0x62, 0x63}},
-    {DAC, MCP4725A2, "MCP4725A2", "", false, {0x64, 0x65}},
-    {DAC, MCP4725A3, "MCP4725A3", "", false, {0x66, 0x67}},
-    {Radio, TEA5767, "TEA5767", "", false, {0x60}},
-    {Radio, Si4713, "Si4713", "", false, {0x11, 0x63}},
-    {Touch, FT6206, "FT6206", "", false, {0x38}},
-    {Touch, STMPE610, "STMPE610", "", false, {0x41}}};
-*/
+    //{Sensor, LSM9DS0_Accel_Mag, "LSM9DS0_Accel_Mag", "", false, {0x1D}},
+    //{Sensor, LSM9DS0_Gyro, "LSM9DS0_Gyro", "", false, {0x6B}},
+    //{Sensor, LSM303_Accel, "LSM303_Accel", "", false, {0x19}},
+    //{Sensor, LSM303_Mag, "LSM303_Mag", "", false, {0x1E}},
+    {RTC, DS1307_3231, "DS1307_3231", "Real time clock", false, {0x68, 0, 0, 0}},
+    {EEPROM, DS1307_EEPROM, "DS1307_EEPORM", "RTC EEPROM", false, {0x50, 0, 0, 0}},
+    //{IO, MCP23008, "MCP23008", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
+    //{IO, MCP23017, "MCP23017", "", false, {0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27}},
+    //{PWM, PCA9685, "PCA9685", "", false, {0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 
+    //                                      0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F}},
+    //{DAC, MCP4725A0, "MCP4725A0", "", false, {0x60, 0x61}},
+    //{DAC, MCP4725A1, "MCP4725A1", "", false, {0x62, 0x63}},
+    //{DAC, MCP4725A2, "MCP4725A2", "", false, {0x64, 0x65}},
+    //{DAC, MCP4725A3, "MCP4725A3", "", false, {0x66, 0x67}},
+    //{Radio, TEA5767, "TEA5767", "", false, {0x60}},
+    //{Radio, Si4713, "Si4713", "", false, {0x11, 0x63}},
+    //{Touch, FT6206, "FT6206", "", false, {0x38}},
+    //{Touch, STMPE610, "STMPE610", "", false, {0x41}}
+    };
+
 namespace meisterwerk {
     namespace base {
         class i2cbus : public meisterwerk::core::entity {
@@ -141,6 +137,13 @@ namespace meisterwerk {
                 DBG("INIT i2c");
             }
 
+            String hexByte(uint8_t byte) {
+                char b[3];
+                itoa(byte,b,16);
+                if (byte<16) return "0"+String(b);
+                else return String(b);
+            }
+
             bool registerEntity() {
                 return meisterwerk::core::entity::registerEntity( 50000 );
             }
@@ -151,16 +154,45 @@ namespace meisterwerk {
                 bEnum  = false;
             }
 
+            int identify(uint8_t address) {
+                int numDevs=0;
+                int last=-1;
+                for (int i=0; i<sizeof(i2cProps)/sizeof(T_I2C_PROPERTIES); i++) {
+                    for (int j=0; j<MAX_I2C_ADDRESS_VAR; j++) {
+                        if (i2cProps[i].addresses[j]==address) {
+                            ++numDevs;
+                            if (last!=-1) {
+                                DBG("Ambiguous:"+String(last)+"<->"+String(i));
+                            }
+                            last=i;
+                        }
+                    }
+                }
+                if (numDevs==1) {
+                    DBG(i2cProps[last].name+", "+i2cProps[last].description+" at port: 0x"+hexByte(address));
+                } else if (numDevs>1) {
+                    last=-1;
+                    DBG("WARNING: ambiguous addresses in I2C hardware detection for address 0x"+hexByte(address)+", cannot securely identify");
+                } else {
+                    last=-1;
+                    DBG("WARNING: device at address 0x"+hexByte(address)+" is of unknown type.");
+                }
+                return last;
+            }
+
             bool check( uint8_t address ) {
                 bool bDevFound = false;
+                // The i2c_scanner uses the return value of
+                // the Write.endTransmisstion to see if
+                // a device did acknowledge to the address.
+                // From: https://playground.arduino.cc/Main/I2cScanner
                 Wire.beginTransmission( address );
                 byte error = Wire.endTransmission();
-
                 if ( error == 0 ) {
                     bDevFound = true;
-                    DBG( "I2C device found at address " + String( address ) + " (dec.)" );
+                    DBG( "I2C device found at address 0x" + hexByte( address ) );
                 } else if ( error == 4 ) {
-                    DBG( "Unknow error at address " + String( address ) + " (dec.)" );
+                    DBG( "Unknow error at address " + hexByte( address ) );
                 }
                 return bDevFound;
             }
@@ -168,6 +200,8 @@ namespace meisterwerk {
             unsigned int i2cScan() {
                 byte  address;
                 String portlist = "";
+                String devlist= "";
+                int niDevs,i2cid;
 
                 if ( !bSetup ) {
                     DBG( "i2cbus not initialized!" );
@@ -177,27 +211,31 @@ namespace meisterwerk {
                 }
 
                 DBG( "Scanning I2C-Bus, SDA=" + String( sdaport ) + ", SCL=" + String( sclport ) );
-                subscribe( "i2cbus/*" );
+                subscribe( "i2cbus/enum" );
 
                 nDevices = 0;
+                niDevs = 0;
                 for ( uint8_t address = 1; address < 127; address++ ) {
-                    // The i2c_scanner uses the return value of
-                    // the Write.endTransmisstion to see if
-                    // a device did acknowledge to the address.
-                    // From: https://playground.arduino.cc/Main/I2cScanner
                     if ( check( address ) ) {
                         nDevices++;
                         if ( nDevices > 1 )
                             portlist += ",";
                         portlist += String( address );
+                        i2cid=identify(address);
+                        if (i2cid!=-1) {
+                            niDevs++;
+                            if (niDevs>1)
+                                devlist+=",";
+                            devlist+="\""+i2cProps[i2cid].name+"\"";
+                        }
                     }
                 }
                 if ( nDevices == 0 ) {
-                    DBG( "No I2C devices found\n" );
+                    DBG( "No I2C devices found" );
                     publish( "i2cbus/offline", "" );
                 } else {
                     String json =
-                        "{\"devs\":" + String( nDevices ) + ",\"portlist\": [" + portlist + "]}";
+                        "{\"devs\":" + String( nDevices ) + ",\"portlist\":[" + portlist + "],\"i2cdevs\":["+devlist+"]}";
                     DBG( "jsonstate i2c:" + json );
                     publish( "i2cbus/online", json );
                 }

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -74,7 +74,8 @@ typedef struct t_i2c_properties {
     unsigned char addresses[16];
 } T_I2C_PROPERTIES;
 
-const T_I2C_PROPERTIES i2cProps[] PROGMEM = {
+/*
+const T_I2C_PROPERTIES i2cProps[] = {
     {OLED, SSD1306, "SSD1306", "OLED-display (128x64)", false, {0x3C, 0x3D}},
     // http://www.solomon-systech.com/en/product/display-ic/oled-driver-controller/ssd1306/
     {NFC, PN532, "PN532", "RFID controller", false, {0x48}},
@@ -121,7 +122,7 @@ const T_I2C_PROPERTIES i2cProps[] PROGMEM = {
     {Radio, Si4713, "Si4713", "", false, {0x11, 0x63}},
     {Touch, FT6206, "FT6206", "", false, {0x38}},
     {Touch, STMPE610, "STMPE610", "", false, {0x41}}};
-
+*/
 namespace meisterwerk {
     namespace base {
         class i2cbus : public meisterwerk::core::entity {
@@ -205,7 +206,6 @@ namespace meisterwerk {
             }
 
             virtual void onLoop( unsigned long ticker ) override {
-                DBG("LOOP");
                 if ( bInternalError )
                     return;
                 if ( !bEnum ) {
@@ -214,7 +214,6 @@ namespace meisterwerk {
             }
             virtual void onReceiveMessage( String topic, const char *pBuf,
                                            unsigned int len ) override {
-                DBG("REC");
                 if ( topic == "i2cbus/enum" ) {
                     i2cScan();
                 }

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -67,7 +67,7 @@ typedef struct t_i2c_properties {
     String        name;
     String        description;
     bool          supported;
-    unsigned char addresses{};
+    unsigned char addresses[];
 } T_I2C_PROPERTIES;
 
 const T_I2C_PROPERTIES i2cProps[] PROGMEM = {

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -2,6 +2,9 @@
 #ifndef i2cbus_h
 #define i2cbus_h
 
+#include <ESP8266WiFi.h>
+#include <Wire.h>
+
 // dependencies
 #include "../core/entity.h"
 
@@ -18,6 +21,7 @@
 
 enum I2CDevType {
     OLED,
+    NFC,
     Sensor,
     RTC,
     IO,
@@ -26,7 +30,7 @@ enum I2CDevType {
     Radio,
     Touch,
     EEPROM,
-}
+};
 
 enum I2CDev {
     SSD1306,
@@ -59,15 +63,15 @@ enum I2CDev {
     Si4713,
     FT6206,
     STMPE610
-}
+};
 
 typedef struct t_i2c_properties {
-    I2CDev        id;
-    I2CDevType    type;
+    I2CDevType        id;
+    I2CDev    type;
     String        name;
     String        description;
     bool          supported;
-    unsigned char addresses[];
+    unsigned char addresses[16];
 } T_I2C_PROPERTIES;
 
 const T_I2C_PROPERTIES i2cProps[] PROGMEM = {
@@ -128,7 +132,7 @@ namespace meisterwerk {
             uint8_t      sdaport, sclport;
             unsigned int nDevices;
 
-            i2cbus( String name, int sdaport, int sclport )
+            i2cbus( String name, uint8_t sdaport, uint8_t sclport )
                 : meisterwerk::core::entity( name ), sdaport{sdaport}, sclport{sclport} {
                 bSetup         = false;
                 bEnum          = false;
@@ -144,7 +148,7 @@ namespace meisterwerk {
             bool check( uint8_t address ) {
                 bool bDevFound = false;
                 Wire.beginTransmission( address );
-                error = Wire.endTransmission();
+                byte error = Wire.endTransmission();
 
                 if ( error == 0 ) {
                     bDevFound = true;
@@ -156,7 +160,7 @@ namespace meisterwerk {
             }
 
             unsigned int i2cScan() {
-                byte   error, address;
+                byte  address;
                 String portlist = "";
 
                 if ( !bSetup ) {
@@ -187,7 +191,7 @@ namespace meisterwerk {
                     publish( "i2cbus/offline", "" );
                 } else {
                     String json =
-                        "{\"devs\":" + String( nDevices ) + ",\"portlist\": [" + portlist "]}";
+                        "{\"devs\":" + String( nDevices ) + ",\"portlist\": [" + portlist + "]}";
                     DBG( "jsonstate i2c:" + json );
                     publish( "i2cbus/online", json );
                 }

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -137,6 +137,11 @@ namespace meisterwerk {
                 bSetup         = false;
                 bEnum          = false;
                 bInternalError = false;
+                DBG("INIT i2c");
+            }
+
+            bool registerEntity() {
+                return meisterwerk::core::entity::registerEntity( 50000 );
             }
 
             virtual void onSetup() override {
@@ -200,6 +205,7 @@ namespace meisterwerk {
             }
 
             virtual void onLoop( unsigned long ticker ) override {
+                DBG("LOOP");
                 if ( bInternalError )
                     return;
                 if ( !bEnum ) {
@@ -208,6 +214,7 @@ namespace meisterwerk {
             }
             virtual void onReceiveMessage( String topic, const char *pBuf,
                                            unsigned int len ) override {
+                DBG("REC");
                 if ( topic == "i2cbus/enum" ) {
                     i2cScan();
                 }

--- a/base/i2cdev.h
+++ b/base/i2cdev.h
@@ -1,0 +1,53 @@
+
+#ifndef i2cdev_h
+#define i2cdev_h
+
+#include <ESP8266WiFi.h>
+
+// dependencies
+#include "../core/entity.h"
+
+namespace meisterwerk {
+    namespace base {
+        class i2cdev : public meisterwerk::core::entity {
+            public:
+            String i2ctype;
+
+            i2cdev( String name, String i2cType )
+                : meisterwerk::core::entity( name ), i2ctype{i2ctype} {
+                DBG("INIT i2cdev");
+            }
+
+            bool registerEntity() {
+                return meisterwerk::core::entity::registerEntity( 50000 );
+            }
+
+            virtual void onSetup() override {
+                DBG("i2cdev pub/sub in setup");
+                subscribe( "i2cbus/online" );
+                publish("i2cbus/enum","");
+            }
+
+            void i2cSetup(String json) {
+                DBG("Received i2c-info: "+json);
+            }
+
+            int l=0;
+            virtual void onLoop( unsigned long ticker ) override {
+                if (l==0) {
+                    l=1;
+                    DBG("first loop call for "+i2ctype);
+                }
+            }
+
+            virtual void onReceiveMessage( String topic, const char *pBuf,
+                                           unsigned int len ) override {
+                if ( topic == "i2cbus/online" ) {
+                    i2cSetup(String(pBuf));
+                }
+            }
+        };
+    } // namespace base
+} // namespace meisterwerk
+
+#endif

--- a/base/i2cdev.h
+++ b/base/i2cdev.h
@@ -2,8 +2,8 @@
 #ifndef i2cdev_h
 #define i2cdev_h
 
-#include <ESP8266WiFi.h>
 #include <ArduinoJson.h>
+#include <ESP8266WiFi.h>
 
 // dependencies
 #include "../core/entity.h"
@@ -14,43 +14,48 @@ namespace meisterwerk {
 
         class SensorProcessor {
             public:
-            int noVals=0;
-            int smoothIntervall;
-            int pollTimeSec;
-            float sum=0.0;
-            float eps;
-            bool first=true;
-            float lastVal=-99999.0;
+            int           noVals = 0;
+            int           smoothIntervall;
+            int           pollTimeSec;
+            float         sum = 0.0;
+            float         eps;
+            bool          first   = true;
+            float         meanVal = 0;
+            float         lastVal = -99999.0;
             unsigned long last;
-        
+
             // average of smoothIntervall measurements
-            // update sensor value, if newvalue differs by at least eps, or if pollTimeSec has elapsed.
-            SensorProcessor(int smoothIntervall=5, int pollTimeSec=60, float eps=0.1): smoothIntervall{smoothIntervall}, 
-                                                                                                pollTimeSec{pollTimeSec}, eps{eps} {
-                last=millis();
+            // update sensor value, if newvalue differs by at least eps, or if pollTimeSec has
+            // elapsed.
+            SensorProcessor( int smoothIntervall = 5, int pollTimeSec = 60, float eps = 0.1 )
+                : smoothIntervall{smoothIntervall}, pollTimeSec{pollTimeSec}, eps{eps} {
+                last = millis();
             }
 
             // changes the value into a smoothed version
             // returns true, if sensor-value is a valid update
             // an update is valid, if the new value differs by at least eps from last last value,
             // or, if pollTimeSec secs have elapsed.
-            bool filter(float *pvalue) {
-                float newVal=(lastVal*noVals+(*pvalue))/(noVals+1);
-                lastVal=newVal;
-                if (noVals<smoothIntervall) ++noVals;
-                float delta=(*pvalue)-newVal;
-                if (delta<0.0) delta= (-1.0)*delta;
-                if (delta>eps || first) {
-                    first=false;
-                    *pvalue=newVal;
-                    last=millis();
+            bool filter( float *pvalue ) {
+                meanVal = ( meanVal * noVals + ( *pvalue ) ) / ( noVals + 1 );
+                if ( noVals < smoothIntervall )
+                    ++noVals;
+                float delta = lastVal - meanVal;
+                if ( delta < 0.0 )
+                    delta = ( -1.0 ) * delta;
+                if ( delta > eps || first ) {
+                    first   = false;
+                    lastVal      = meanVal;
+                    *pvalue = meanVal;
+                    last    = millis();
                     return true;
                 } else {
-                    if (pollTimeSec!=0) {
+                    if ( pollTimeSec != 0 ) {
                         // XXX: use Leo's megaticker:
-                        if (millis()-last > pollTimeSec*1000L) {
-                            *pvalue=newVal;
-                            last=millis();
+                        if ( millis() - last > pollTimeSec * 1000L ) {
+                            *pvalue = meanVal;
+                            last    = millis();
+                            lastVal      = meanVal;
                             return true;
                         }
                     }
@@ -72,51 +77,50 @@ namespace meisterwerk {
             }
 
             virtual void onSetup() override {
-                DBG("i2cdev pub/sub in setup");
+                DBG( "i2cdev pub/sub in setup" );
                 subscribe( "i2cbus/online" );
-                publish("i2cbus/enum","");
+                publish( "i2cbus/enum", "" );
             }
 
-            virtual void instantiate(String i2ctype, uint8_t address) {
-                DBG("Your code should override this function and instantiate a "+i2ctype+" device at address 0x"+hexByte(address));
+            virtual void instantiate( String i2ctype, uint8_t address ) {
+                DBG( "Your code should override this function and instantiate a " + i2ctype +
+                     " device at address 0x" + hexByte( address ) );
             }
 
-            void i2cSetup(String json) {
-                bool ok=false;
-                DBG("Received i2c-info: "+json);
-                DynamicJsonBuffer  jsonBuffer(200);
-                JsonObject& root = jsonBuffer.parseObject(json);
-                if (!root.success()) {
-                    DBG("Invalid JSON received!");
+            void i2cSetup( String json ) {
+                bool ok = false;
+                DBG( "Received i2c-info: " + json );
+                DynamicJsonBuffer jsonBuffer( 200 );
+                JsonObject &      root = jsonBuffer.parseObject( json );
+                if ( !root.success() ) {
+                    DBG( "Invalid JSON received!" );
                     return;
                 }
-                JsonArray& devs=root["i2cdevs"];
-                JsonArray& ports=root["portlist"];
-                for (int i=0; i<devs.size(); i++) {
-                    String dev=devs[i];
-                    uint8_t address=(uint8_t)ports[i];
-                    DBG(i2ctype+"<->"+dev);
-                    if (dev==i2ctype) {
-                        instantiate(i2ctype, address);
+                JsonArray &devs  = root["i2cdevs"];
+                JsonArray &ports = root["portlist"];
+                for ( int i = 0; i < devs.size(); i++ ) {
+                    String  dev     = devs[i];
+                    uint8_t address = (uint8_t)ports[i];
+                    DBG( i2ctype + "<->" + dev );
+                    if ( dev == i2ctype ) {
+                        instantiate( i2ctype, address );
                     }
                 }
-
             }
 
             virtual void onLoop( unsigned long ticker ) override {
-                
             }
-/*
-            virtual void onReceiveMessage( String topic, const char *pBuf,
-                                           unsigned int len ) override {
-                if ( topic == "i2cbus/online" ) {
-                    i2cSetup(String(pBuf));
-                }
-            }
-*/
+            /*
+                        virtual void onReceiveMessage( String topic, const char *pBuf,
+                                                       unsigned int len ) override {
+                            if ( topic == "i2cbus/online" ) {
+                                i2cSetup(String(pBuf));
+                            }
+                        }
+            */
             virtual void onReceive( String topic, String msg ) override {
                 if ( topic == "i2cbus/online" ) {
-                    i2cSetup(msg);
+                    i2cSetup( msg );
                 }
             }
         };

--- a/base/i2cdev.h
+++ b/base/i2cdev.h
@@ -62,11 +62,17 @@ namespace meisterwerk {
                     DBG("first loop call for "+i2ctype);
                 }
             }
-
+/*
             virtual void onReceiveMessage( String topic, const char *pBuf,
                                            unsigned int len ) override {
                 if ( topic == "i2cbus/online" ) {
                     i2cSetup(String(pBuf));
+                }
+            }
+*/
+            virtual void onReceive( String topic, String msg ) override {
+                if ( topic == "i2cbus/online" ) {
+                    i2cSetup(msg);
                 }
             }
         };

--- a/base/i2cdev.h
+++ b/base/i2cdev.h
@@ -47,6 +47,7 @@ namespace meisterwerk {
                     return true;
                 } else {
                     if (pollTimeSec!=0) {
+                        // XXX: use Leo's megaticker:
                         if (millis()-last > pollTimeSec*1000L) {
                             *pvalue=newVal;
                             last=millis();

--- a/core/scheduler.h
+++ b/core/scheduler.h
@@ -197,6 +197,7 @@ namespace meisterwerk {
                 return true;
             }
 
+            public:
             static bool msgmatches( String s1, String s2 ) {
                 // compares topic-paths <subtopic>/<subtopic/...
                 // the compare is symmetric, s1==s2 <=> s2==s1.

--- a/thing/i2cdev-BMP085.h
+++ b/thing/i2cdev-BMP085.h
@@ -22,7 +22,9 @@ namespace meisterwerk {
             String json;
 
             i2cdev_BMP085( String name)
-                : meisterwerk::base::i2cdev( name, "BMP085" ) {
+                : meisterwerk::base::i2cdev( name, "BMP085" ), tempProcessor(5, 600, 0.1), pressProcessor(10, 600, 0.05) {
+                    // send temperature updates, if temperature changes for 0.1C over an average of 5 measurements, but at least every 15min
+                    // send pressure update, if pressure changes for 0.05mbar over an average of 10 measurements, but at least every 15min
             }
             ~i2cdev_BMP085() {
                 if (pollSensor) {
@@ -32,6 +34,7 @@ namespace meisterwerk {
             }
 
             bool registerEntity() {
+                // 5sec sensor checks
                 return meisterwerk::core::entity::registerEntity( 5000000 );
             }
 

--- a/thing/i2cdev-BMP085.h
+++ b/thing/i2cdev-BMP085.h
@@ -22,8 +22,8 @@ namespace meisterwerk {
             String json;
 
             i2cdev_BMP085( String name)
-                : meisterwerk::base::i2cdev( name, "BMP085" ), tempProcessor(5, 600, 0.1), pressProcessor(10, 600, 0.05) {
-                    // send temperature updates, if temperature changes for 0.1C over an average of 5 measurements, but at least every 15min
+                : meisterwerk::base::i2cdev( name, "BMP085" ), tempProcessor(5, 900, 0.1), pressProcessor(10, 900, 0.05) {
+                    // send temperature updates, if temperature changes for 0.1C over an average of 5 measurements, but at least every 15min (900sec)
                     // send pressure update, if pressure changes for 0.05mbar over an average of 10 measurements, but at least every 15min
             }
             ~i2cdev_BMP085() {

--- a/thing/i2cdev-BMP085.h
+++ b/thing/i2cdev-BMP085.h
@@ -1,0 +1,65 @@
+
+#ifndef i2cdev_BMP085_h
+#define i2cdev_BMP085_h
+
+#include <ESP8266WiFi.h>
+#include <ArduinoJson.h>
+
+// dependencies
+#include "../core/entity.h"
+#include "../base/i2cdev.h"
+#include "../util/hextools.h"
+
+#include <Adafruit_BMP085.h>
+
+namespace meisterwerk {
+    namespace base {
+        class i2cdev_BMP085 : public meisterwerk::base::i2cdev {
+            public:
+            Adafruit_BMP085 *pbmp;
+            bool pollSensor=false;
+
+            i2cdev_BMP085( String name)
+                : meisterwerk::base::i2cdev( name, "BMP085" ) {
+            }
+            ~i2cdev_BMP085() {
+                if (pollSensor) {
+                    pollSensor=false;
+                    delete pbmp;
+                }
+            }
+
+            bool registerEntity() {
+                return meisterwerk::core::entity::registerEntity( 5000000 );
+            }
+
+            virtual void instantiate(String i2ctype, uint8_t address) override {
+                DBG("Instantiating BMP085 device at address 0x"+hexByte(address));
+                pbmp = new Adafruit_BMP085();
+                if (!pbmp->begin()) {
+                    DBG("BMP085 initialization failure.");
+                } else {
+                    pollSensor=true;
+                }
+            }
+
+            virtual void onLoop( unsigned long ticker ) override {
+                if (pollSensor) {
+                    float temperature=pbmp->readTemperature();
+                    float pressure=pbmp->readPressure()/100.0;
+                    String json =
+                        "{\"temperature\":" + String( temperature ) + "}";
+                    DBG( "jsonstate i2c bmp085:" + json );
+                    publish( entName+"/temperature", json );
+                    json =
+                        "{\"pressure\":" +String(pressure)+"}";
+                    DBG( "jsonstate i2c bmp085:" + json );
+                    publish( entName+"/pressure", json ); 
+                }
+            }
+
+        };
+    } // namespace base
+} // namespace meisterwerk
+
+#endif

--- a/thing/i2cdev-BMP085.h
+++ b/thing/i2cdev-BMP085.h
@@ -45,6 +45,7 @@ namespace meisterwerk {
                     DBG("BMP085 initialization failure.");
                 } else {
                     pollSensor=true;
+                    subscribe(entName+"/config");
                 }
             }
 
@@ -68,7 +69,7 @@ namespace meisterwerk {
             void config(String msg) {
                 // XXX: do things
             }
-            
+
             virtual void onReceive( String topic, String msg ) override {
                 meisterwerk::base::i2cdev::onReceive( topic, msg);
                 if ( topic == entName+"/config" ) {

--- a/thing/i2cdev-BMP085.h
+++ b/thing/i2cdev-BMP085.h
@@ -65,6 +65,17 @@ namespace meisterwerk {
                 }
             }
 
+            void config(String msg) {
+                // XXX: do things
+            }
+            
+            virtual void onReceive( String topic, String msg ) override {
+                meisterwerk::base::i2cdev::onReceive( topic, msg);
+                if ( topic == entName+"/config" ) {
+                    config( msg );
+                }
+            }
+
         };
     } // namespace base
 } // namespace meisterwerk

--- a/thing/i2cdev-BMP085.h
+++ b/thing/i2cdev-BMP085.h
@@ -1,34 +1,44 @@
+// Copyright Dominik Schloesser and Leo Moll 2017
+// MIT License
+//
+// MeisterWerk IoT Framework
+// https://github.com/YeaSoft/MeisterWerk/
+// If you like this project, please add a star!
 
-#ifndef i2cdev_BMP085_h
-#define i2cdev_BMP085_h
+#pragma once
 
+// hardware dependencies
+#include <Adafruit_BMP085.h>
 #include <ESP8266WiFi.h>
+
+// external libraries
 #include <ArduinoJson.h>
 
 // dependencies
-#include "../core/entity.h"
 #include "../base/i2cdev.h"
+#include "../core/entity.h"
 #include "../util/hextools.h"
 
-#include <Adafruit_BMP085.h>
-
 namespace meisterwerk {
-    namespace base {
+    namespace thing {
         class i2cdev_BMP085 : public meisterwerk::base::i2cdev {
             public:
-            Adafruit_BMP085 *pbmp;
-            bool pollSensor=false;
-            SensorProcessor tempProcessor, pressProcessor;
-            String json;
+            Adafruit_BMP085 *                  pbmp;
+            bool                               pollSensor = false;
+            meisterwerk::util::sensorprocessor tempProcessor, pressProcessor;
+            String                             json;
 
-            i2cdev_BMP085( String name)
-                : meisterwerk::base::i2cdev( name, "BMP085" ), tempProcessor(5, 900, 0.1), pressProcessor(10, 900, 0.05) {
-                    // send temperature updates, if temperature changes for 0.1C over an average of 5 measurements, but at least every 15min (900sec)
-                    // send pressure update, if pressure changes for 0.05mbar over an average of 10 measurements, but at least every 15min
+            i2cdev_BMP085( String name )
+                : meisterwerk::base::i2cdev( name, "BMP085" ), tempProcessor( 5, 900, 0.1 ),
+                  pressProcessor( 10, 900, 0.05 ) {
+                // send temperature updates, if temperature changes for 0.1C over an average of 5
+                // measurements, but at least every 15min (900sec)
+                // send pressure update, if pressure changes for 0.05mbar over an average of 10
+                // measurements, but at least every 15min
             }
             ~i2cdev_BMP085() {
-                if (pollSensor) {
-                    pollSensor=false;
+                if ( pollSensor ) {
+                    pollSensor = false;
                     delete pbmp;
                 }
             }
@@ -38,47 +48,45 @@ namespace meisterwerk {
                 return meisterwerk::core::entity::registerEntity( 5000000 );
             }
 
-            virtual void instantiate(String i2ctype, uint8_t address) override {
-                DBG("Instantiating BMP085 device at address 0x"+hexByte(address));
+            virtual void onInstantiate( String i2ctype, uint8_t address ) override {
+                DBG( "Instantiating BMP085 device at address 0x" +
+                     meisterwerk::utils::hexByte( address ) );
                 pbmp = new Adafruit_BMP085();
-                if (!pbmp->begin()) {
-                    DBG("BMP085 initialization failure.");
+                if ( !pbmp->begin() ) {
+                    DBG( "BMP085 initialization failure." );
                 } else {
-                    pollSensor=true;
-                    subscribe(entName+"/config");
+                    pollSensor = true;
+                    subscribe( entName + "/config" );
                 }
             }
 
             virtual void onLoop( unsigned long ticker ) override {
-                if (pollSensor) {
-                    float temperature=pbmp->readTemperature();
-                    if (tempProcessor.filter(&temperature)) {
+                if ( pollSensor ) {
+                    float temperature = pbmp->readTemperature();
+                    if ( tempProcessor.filter( &temperature ) ) {
                         json = "{\"temperature\":" + String( temperature ) + "}";
                         DBG( "jsonstate i2c bmp085:" + json );
-                        publish( entName+"/temperature", json );
+                        publish( entName + "/temperature", json );
                     }
-                    float pressure=pbmp->readPressure()/100.0;
-                    if (pressProcessor.filter(&pressure)) {
-                        json = "{\"pressure\":" +String(pressure)+"}";
+                    float pressure = pbmp->readPressure() / 100.0;
+                    if ( pressProcessor.filter( &pressure ) ) {
+                        json = "{\"pressure\":" + String( pressure ) + "}";
                         DBG( "jsonstate i2c bmp085:" + json );
-                        publish( entName+"/pressure", json ); 
+                        publish( entName + "/pressure", json );
                     }
                 }
             }
 
-            void config(String msg) {
-                // XXX: do things
-            }
-
             virtual void onReceive( String topic, String msg ) override {
-                meisterwerk::base::i2cdev::onReceive( topic, msg);
-                if ( topic == entName+"/config" ) {
+                meisterwerk::base::i2cdev::onReceive( topic, msg );
+                if ( topic == entName + "/config" ) {
                     config( msg );
                 }
             }
 
+            void config( String msg ) {
+                // XXX: do things
+            }
         };
     } // namespace base
 } // namespace meisterwerk
-
-#endif

--- a/util/hextools.h
+++ b/util/hextools.h
@@ -1,0 +1,10 @@
+#pragma once
+
+String hexByte( uint8_t byte ) {
+    char b[3];
+    itoa( byte, b, 16 );
+    if ( byte < 16 )
+        return "0" + String( b );
+    else
+        return String( b );
+}

--- a/util/hextools.h
+++ b/util/hextools.h
@@ -1,10 +1,22 @@
+// Copyright Dominik Schloesser and Leo Moll 2017
+// MIT License
+//
+// MeisterWerk IoT Framework
+// https://github.com/YeaSoft/MeisterWerk/
+// If you like this project, please add a star!
+
 #pragma once
 
-String hexByte( uint8_t byte ) {
-    char b[3];
-    itoa( byte, b, 16 );
-    if ( byte < 16 )
-        return "0" + String( b );
-    else
-        return String( b );
+namespace meisterwerk {
+    namespace util {
+
+        String hexByte( uint8_t byte ) {
+            char b[3];
+            itoa( byte, b, 16 );
+            if ( byte < 16 )
+                return "0" + String( b );
+            else
+                return String( b );
+        }
+    }
 }

--- a/util/sensorprocessor.h
+++ b/util/sensorprocessor.h
@@ -1,0 +1,66 @@
+// Copyright Dominik Schloesser and Leo Moll 2017
+// MIT License
+//
+// MeisterWerk IoT Framework
+// https://github.com/YeaSoft/MeisterWerk/
+// If you like this project, please add a star!
+
+#pragma once
+
+namespace meisterwerk {
+    namespace util {
+
+        class sensorprocessor {
+            public:
+            int           noVals = 0;
+            int           smoothIntervall;
+            int           pollTimeSec;
+            float         sum = 0.0;
+            float         eps;
+            bool          first   = true;
+            float         meanVal = 0;
+            float         lastVal = -99999.0;
+            unsigned long last;
+
+            // average of smoothIntervall measurements
+            // update sensor value, if newvalue differs by at least eps, or if pollTimeSec has
+            // elapsed.
+            sensorprocessor( int smoothIntervall = 5, int pollTimeSec = 60, float eps = 0.1 )
+                : smoothIntervall{smoothIntervall}, pollTimeSec{pollTimeSec}, eps{eps} {
+                last = millis();
+            }
+
+            // changes the value into a smoothed version
+            // returns true, if sensor-value is a valid update
+            // an update is valid, if the new value differs by at least eps from last last value,
+            // or, if pollTimeSec secs have elapsed.
+            bool filter( float *pvalue ) {
+                meanVal = ( meanVal * noVals + ( *pvalue ) ) / ( noVals + 1 );
+                if ( noVals < smoothIntervall ) {
+                    ++noVals;
+                }
+                float delta = lastVal - meanVal;
+                if ( delta < 0.0 ) {
+                    delta = ( -1.0 ) * delta;
+                }
+                if ( delta > eps || first ) {
+                    first   = false;
+                    lastVal = meanVal;
+                    *pvalue = meanVal;
+                    last    = millis();
+                    return true;
+                } else {
+                    if ( pollTimeSec != 0 ) {
+                        if ( timebudget::delta( last, millis() ) > pollTimeSec * 1000L ) {
+                            *pvalue = meanVal;
+                            last    = millis();
+                            lastVal = meanVal;
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Three entity-layers for i2c:
i2cbus: the bus enumerator
i2cdev: the superclass for i2c device implementations. Listens to infos from i2cbus, and only sends an instantiation-call, if the hardware is actually available.
i2cdev_BMP085: subclass of i2cdev, implements pressure/temperature sensor. The sensor class is only instantiated, if the hardware is found by i2cbus.
