### PR TITLE
core::application is now derived from core::entity (Close #18)

### DIFF
--- a/base/button.h
+++ b/base/button.h
@@ -33,7 +33,7 @@ namespace meisterwerk {
                 lastChange = 0;
             }
 
-            virtual void onSetup() override {
+            virtual void onRegister() override {
                 subscribe( entName + "/getstate" );
             }
 

--- a/base/i2cbus.h
+++ b/base/i2cbus.h
@@ -148,7 +148,7 @@ namespace meisterwerk {
                 return meisterwerk::core::entity::registerEntity( 50000 );
             }
 
-            virtual void onSetup() override {
+            virtual void onRegister() override {
                 Wire.begin( sdaport, sclport ); // SDA, SCL;
                 bSetup = true;
                 bEnum  = false;

--- a/base/i2cdev.h
+++ b/base/i2cdev.h
@@ -33,7 +33,7 @@ namespace meisterwerk {
                 return meisterwerk::core::entity::registerEntity( 50000 );
             }
 
-            virtual void onSetup() override {
+            virtual void onRegister() override {
                 DBG( "i2cdev pub/sub in setup" );
                 subscribe( "i2cbus/online" );
                 publish( "i2cbus/enum", "" );

--- a/base/pushbutton.h
+++ b/base/pushbutton.h
@@ -35,8 +35,8 @@ namespace meisterwerk {
                 minExtraLongMs = _minExtraLongMs;
             }
 
-            virtual void onSetup() override {
-                button::onSetup();
+            virtual void onRegister() override {
+                button::onRegister();
                 subscribe( entName + "/config" );
             }
 

--- a/core/baseapp.h
+++ b/core/baseapp.h
@@ -6,29 +6,30 @@
 #pragma once
 
 // dependencies
+#include "entity.h"
 #include "scheduler.h"
 
 namespace meisterwerk {
     namespace core {
 
-        class baseapp {
+        class baseapp : public entity {
             public:
             // static members
             static baseapp *_app;
 
             // members
-            String    appName;
             scheduler sched;
 
             // mthods
-            baseapp( String name ) {
-                appName = name;
-                _app    = this;
+            baseapp( String name ) : entity( name ) {
+                _app = this;
             }
 
             virtual void onSetup() {
             }
 
+            // there is no clash between baseapp:onLoop and entity;:onLoop
+            // because of the number of parameters.
             virtual void onLoop() {
                 sched.loop();
             }

--- a/core/entity.h
+++ b/core/entity.h
@@ -89,10 +89,12 @@ namespace meisterwerk {
                 return false;
             }
 
-            virtual void onSetup() {
-                DBG( "entity::onSetup, missing override for entity " + entName );
+            virtual void onRegister() {
+                DBG( "entity::onRegister, missing override for entity " + entName );
             }
 
+            // there is no clash between baseapp:onLoop and entity;:onLoop
+            // because of the number of parameters.
             virtual void onLoop( unsigned long ticker ) {
                 DBG( "entity:onLook, missing override for entity " + entName );
             }

--- a/core/scheduler.h
+++ b/core/scheduler.h
@@ -194,7 +194,7 @@ namespace meisterwerk {
                     return false;
                 }
                 taskList.push_back( pTask );
-                pEnt->onSetup();
+                pEnt->onRegister();
                 return true;
             }
 

--- a/thing/gpiobutton.h
+++ b/thing/gpiobutton.h
@@ -18,7 +18,7 @@ namespace meisterwerk {
                 return meisterwerk::core::entity::registerEntity( 50000 );
             }
 
-            virtual void onSetup() override {
+            virtual void onRegister() override {
                 pinMode( pin, INPUT );
                 fromState  = digitalRead( pin ) == LOW;
                 lastChange = micros();

--- a/thing/gpiopushbutton.h
+++ b/thing/gpiopushbutton.h
@@ -20,7 +20,7 @@ namespace meisterwerk {
                 return meisterwerk::core::entity::registerEntity( 50000 );
             }
 
-            virtual void onSetup() override {
+            virtual void onRegister() override {
                 pinMode( pin, INPUT );
                 fromState  = digitalRead( pin ) == LOW;
                 lastChange = micros();

--- a/util/dumper.h
+++ b/util/dumper.h
@@ -43,7 +43,7 @@ namespace meisterwerk {
                 return meisterwerk::core::entity::registerEntity( 1000000 );
             }
 
-            void onSetup() override {
+            void onRegister() override {
                 dumpSystemInfo();
                 // explicit commands
                 subscribe( "*/dump" );

--- a/util/messagespy.h
+++ b/util/messagespy.h
@@ -37,7 +37,7 @@ namespace meisterwerk {
 #endif
 
 #ifdef DEBUG
-            void onSetup() override {
+            void onRegister() override {
                 subscribe( tmpSubscribedTopic );
                 tmpSubscribedTopic = "";
             }


### PR DESCRIPTION
* core::application is now derived from core::entity
* core::scheduler now invokes `onRegister` instead on `onSetup`
* All occurrences of `onSetup` to `onRegister`