### PR TITLE
Spytime: filter newlines

### DIFF
--- a/util/messagespy.h
+++ b/util/messagespy.h
@@ -47,6 +47,7 @@ namespace meisterwerk {
                 String tmillis = String( millis() );
                 while ( tmillis.length() < 10 )
                     tmillis = "0" + tmillis;
+                msg.replace( "\n", "␤" );
                 Serial.println( tmillis + ":" + entName + ": origin='" + origin + "' topic='" + topic + "' body='" +
                                 msg + "'" );
                 meisterwerk::core::entity::processMessage( origin, topic, msg );

--- a/util/messagespy.h
+++ b/util/messagespy.h
@@ -44,9 +44,9 @@ namespace meisterwerk {
             }
 
             virtual void processMessage( String origin, String topic, String msg ) override {
-                char szBuffer[16];
+                char szBuffer[24];
 
-                sprintf( szBuffer, "%010d:", millis() );
+                sprintf( szBuffer, "%010ld:", millis() );
                 msg.replace( "\n", "␤" );
                 Serial.println( szBuffer + entName + ": origin='" + origin + "' topic='" + topic + "' body='" + msg +
                                 "'" );


### PR DESCRIPTION
Another small change: replace newlines ini spy-logs. display now often receives display-messages that contain newlines in order to reduce the number of message transactions. Those mess up the log.
The N/L character ␤ is debatable.